### PR TITLE
correct sst_anom usage to use nml value

### DIFF
--- a/simple/ice_model.F90
+++ b/simple/ice_model.F90
@@ -1110,7 +1110,7 @@ print *, 'pe,count(ice,all,ocean)=',fms_mpp_pe(),count(Ice%ice_mask),count(Ice%m
 ! this perturbation may be useful in accessing model sensitivities
 
   if ( abs(sst_anom) > 0.0001 ) then
-    Ice%t_surf(:,:) = Ice%t_surf(:,:) + fms_amip_interp_sst_anom
+    Ice%t_surf(:,:) = Ice%t_surf(:,:) + sst_anom
   endif
 
 !----------------------------------------------------------


### PR DESCRIPTION
During the libFMS updates, it seems this line was updated when it shouldn't have been. It should be using the namelist's value rather than pulling in the variable of the same name from amip_interp.